### PR TITLE
Update Plugin Version and fix 1by1 merge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.399</version>
+		<version>1.420</version>
 	</parent>
 
 	<artifactId>jigomerge</artifactId>

--- a/src/main/resources/scripts/jigomerge-2.2.6.groovy
+++ b/src/main/resources/scripts/jigomerge-2.2.6.groovy
@@ -137,7 +137,7 @@ public class SvnMergeTool {
           }
         } else {
           if (mergeOneByOne) {
-            svnMergeAndCommit(mergeUrl, revision, validationScript, workingDirectory)
+            svnMergeAndCommit(mergeUrl, [revision], validationScript, workingDirectory)
           } else {
             printOut.println '  Revision ' + revision + ' has no conflict'
             // add current revision to revisions to be merged


### PR DESCRIPTION
- Updated POM to work with 1.420 or greater
- Also fixed an issue with the 1-by-1 merge where it would throw groovy.lang.MissingMethodException every single time it found revisions to merge
